### PR TITLE
README.md expand import examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ npm install --save es-iterator-helpers
 
 ## Usage/Examples
 
+Using explicit imports:
+
 ```js
 const map = require('es-iterator-helpers/Iterator.prototype.map');
 const toArray = require('es-iterator-helpers/Iterator.prototype.toArray');
@@ -67,10 +69,21 @@ assert.deepEqual(
 );
 ```
 
-```js
-require('./auto'); // shim all of the methods
+Shim using `require`:
 
-require('./Iterator.prototype.map/auto'); // shim the “map” method
+```js
+require('es-iterator-helpers/auto'); // shim all of the methods
+
+require('es-iterator-helpers/Iterator.prototype.map/auto'); // shim the “map” method
+```
+
+Shim using `import` syntax:
+
+[](#preventEval)
+```js
+import 'es-iterator-helpers/auto'; // shim all of the methods
+
+import 'es-iterator-helpers/Iterator.prototype.map/auto'; // shim the “map” method
 ```
 
 ## Tests


### PR DESCRIPTION
Proposal to expanded the README to what I was looking for to get started. Feel free to change.

I was also not sure what this sentence means:

> Because the `Iterator.prototype` methods depend on a receiver (the `this` value), the main export in each subdirectory takes the string to operate on as the first argument.

Does it relate to explicit imports instead of shimming or is it an implementation detail?